### PR TITLE
Update CircleCI

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,25 @@
+#
+# Custom CircleCI Docker image for nisgl-ts
+# Usage
+# cd .circleci/
+# docker build -t nismit/nisgl-ts-node .
+# docker images (Make sure that the image is built)
+# docker login
+# docker push nismit/nisgl-ts-node:latest
+#
+
+# Use CircleCI Node v12.13
+FROM circleci/node:12.13
+
+# Change user to root for setting up
+USER root
+
+# Update base packages
+# And install xvfb, dev packages, then clean up
+RUN apt-get update \
+    && apt-get install -y xvfb libxi-dev libgl1-mesa-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Change user to circleci
+USER circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
-# Javascript Node CircleCI 2.0 configuration file
 #
-# Check {{ '/2.0/language-javascript/' | docs_url }} for more details
+# CircleCI Config
+# Use custom docker image (Ref: Dockerfile)
 #
 version: 2.0
 
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:8.9.1
+    - image: nismit/nisgl-ts-node
 
 jobs:
   test:
@@ -23,7 +23,7 @@ jobs:
       - run: npm install
       - run:
           name: Run tests
-          command: npm test
+          command: xvfb-run -s "-ac -screen 0 1920x1080x24" npm test
 
       - save_cache:
           paths:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nisgl-ts",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "WebGL Base Library with TypeScript",
   "main": "./dist/index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
If `npm test` runs on CircleCI, CircleCI node docker image does not have xvfb for rendering.
Created a new Docker image with xvfb installed.