### PR TITLE
Fix CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,5 +59,5 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-             branches:
+            branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,15 +53,11 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only:
-                - master
       - deploy:
           requires:
             - test
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only:
-                - master
+             branches:
+              ignore: /.*/


### PR DESCRIPTION
CircleCI does not allow to use tags and branch in filters rule, fix to use the only tag.